### PR TITLE
fix: compute network usage percent and add tests

### DIFF
--- a/exporter/exporters.py
+++ b/exporter/exporters.py
@@ -101,7 +101,7 @@ class GPUExporter(Exporter):
 
 class NetworkExporter(Exporter):
     """
-    Eksporter danych o przesyłanych danych sieciowych do pliku CSV.
+    Eksporter przesyłanych danych sieciowych do pliku CSV.
 
     Args:
         label: Nazwa metryki (NET_UP/NET_DOWN).

--- a/monitor/base_monitor.py
+++ b/monitor/base_monitor.py
@@ -16,6 +16,7 @@ class BaseMonitor(ABC):
     @abstractmethod
     def get_usage(self) -> BaseUsage:
         """
-        Zwraca dane o użyciu danego zasobu jako obiekt.
+        Zwraca dane o użyciu danego zasobu jako obiekt lub listę obiektów
+        ``BaseUsage``.
         """
         pass

--- a/monitor/network_monitor.py
+++ b/monitor/network_monitor.py
@@ -18,11 +18,21 @@ class NetworkUsage(BaseUsage):
         self.download_kbps = download_kbps
 
     @property
-    def percent(self):
+    def percent(self) -> float:
         """
         Zwraca procentowe wykorzystanie sieci.
+
+        Wylicza udział sumy prędkości wysyłania i pobierania w
+        maksymalnej przepustowości interfejsów sieciowych. Jeżeli
+        prędkość interfejsów jest niedostępna, zwracane jest 0.
         """
-        return 0
+        stats = psutil.net_if_stats()
+        total_speed_mbps = sum(s.speed for s in stats.values() if s.speed > 0)
+        if total_speed_mbps <= 0:
+            return 0.0
+        max_kbps = total_speed_mbps * 128  # Mbps -> KB/s
+        current_kbps = self.upload_kbps + self.download_kbps
+        return (current_kbps / max_kbps) * 100
 
 
 class NetworkMonitor(BaseMonitor):

--- a/tests/test_network_monitor.py
+++ b/tests/test_network_monitor.py
@@ -1,0 +1,24 @@
+import types
+import pytest
+
+
+def test_network_monitor_reports_mocked_speeds(monkeypatch):
+    from monitor import network_monitor as nm
+
+    counters = [
+        types.SimpleNamespace(bytes_sent=1000, bytes_recv=2000),
+        types.SimpleNamespace(bytes_sent=1000, bytes_recv=2000),
+        types.SimpleNamespace(bytes_sent=1300, bytes_recv=2600),
+        types.SimpleNamespace(bytes_sent=1300, bytes_recv=2600),
+    ]
+    times = [0.0, 1.0]
+
+    monkeypatch.setattr(nm.psutil, "net_io_counters", lambda: counters.pop(0))
+    monkeypatch.setattr(nm, "time", lambda: times.pop(0))
+
+    monitor = nm.NetworkMonitor()
+    usage = monitor.get_usage()
+
+    assert usage.upload_kbps == pytest.approx(300 / 1024)
+    assert usage.download_kbps == pytest.approx(600 / 1024)
+


### PR DESCRIPTION
## Summary
- calculate network utilization based on interface bandwidth
- tidy docstrings for exporter and base monitor
- cover network monitor upload/download calculations with unit test
- type hint network usage percent property

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71f6afed88331ae598a95d83a70af