### PR TITLE
feat: make safe_call configurable and log errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,7 +176,7 @@ class ResourceMonitorApp:
         self.fills[label] = fill
         return idx + 1
 
-    @safe_call
+    @safe_call()
     def update_plot(self, frame):
         """
         Aktualizuje dane oraz rysuje wykresy w regularnych odstępach czasu.

--- a/monitor/utils.py
+++ b/monitor/utils.py
@@ -1,29 +1,40 @@
 import functools
-from typing import Callable
+import logging
+from typing import Any, Callable
 
 
-def safe_call(func: Callable) -> Callable:
+def safe_call(default: Any = None) -> Callable:
     """
     Dekorator obsługujący wyjątki przy wywołaniach monitorów.
-    Jeśli wystąpi błąd, zwraca -1.0 zamiast przerywać działanie programu.
+    Jeśli wystąpi błąd, zwraca ``default`` zamiast przerywać działanie programu.
+
     Args:
-        func: Funkcja do dekorowania.
+        default: Wartość zwracana w razie wystąpienia wyjątku.
+
     Returns:
-        Funkcja dekorowana, która obsługuje wyjątki.
+        Dekorator opakowujący funkcję tak, by zwracała wartość domyślną
+        w przypadku błędu.
     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        """
-        Funkcja opakowująca, która obsługuje wyjątki.
-        Args:
-            *args: Argumenty pozycyjne przekazywane do funkcji.
-            **kwargs: Argumenty nazwane przekazywane do funkcji.
-        Returns:
-            Wynik funkcji lub -1.0 w przypadku błędu.
-        """
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            print(f"Błąd podczas wykonywania {func.__name__}: {e}")
-            return -1.0
-    return wrapper
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            """
+            Funkcja opakowująca, która obsługuje wyjątki.
+
+            Args:
+                *args: Argumenty pozycyjne przekazywane do funkcji.
+                **kwargs: Argumenty nazwane przekazywane do funkcji.
+
+            Returns:
+                Wynik funkcji lub ``default`` w przypadku błędu.
+            """
+            try:
+                return func(*args, **kwargs)
+            except Exception:
+                logging.exception("Błąd podczas wykonywania %s", func.__name__)
+                return default
+
+        return wrapper
+
+    return decorator

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,14 @@
-def test_safe_call_returns_default_on_error(capsys):
+def test_safe_call_returns_default_on_error(caplog):
     from monitor.utils import safe_call
 
-    @safe_call
+    @safe_call(default=-1.0)
     def boom():
         raise RuntimeError("x")
 
-    assert boom() == -1.0
-    out = capsys.readouterr().out
-    assert "Błąd podczas wykonywania" in out
+    with caplog.at_level("ERROR"):
+        assert boom() == -1.0
 
+    assert any(
+        "Błąd podczas wykonywania" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- allow `safe_call` decorator to specify a default return value
- log monitor errors via `logging.exception`
- adjust main and tests for updated decorator API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7240c783883318e4708623efdcccb