### PR TITLE
feat: add JSON exporter and error handling

### DIFF
--- a/exporter/exporters.py
+++ b/exporter/exporters.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from typing import List, Dict
 
 
@@ -35,11 +36,14 @@ class CPUExporter(Exporter):
             y_data: Wartości metryki.
             label: Etykieta kolumny.
         """
-        with open(filename, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(["Czas (s)", label])
-            for x, y in zip(x_data, y_data):
-                writer.writerow([x, y])
+        try:
+            with open(filename, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(["Czas (s)", label])
+                for x, y in zip(x_data, y_data):
+                    writer.writerow([x, y])
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc
 
 
 class RAMExporter(Exporter):
@@ -50,11 +54,14 @@ class RAMExporter(Exporter):
         """
         Eksportuje dane RAM do pliku CSV.
         """
-        with open(filename, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(["Czas (s)", "RAM (%)"])
-            for x, y in zip(x_data, y_data):
-                writer.writerow([x, y])
+        try:
+            with open(filename, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(["Czas (s)", "RAM (%)"])
+                for x, y in zip(x_data, y_data):
+                    writer.writerow([x, y])
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc
 
 
 class DiskExporter(Exporter):
@@ -71,11 +78,14 @@ class DiskExporter(Exporter):
         """
         Eksportuje dane dysku do pliku CSV.
         """
-        with open(filename, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(["Czas (s)", f"Dysk {self.mount} (%)"])
-            for x, y in zip(x_data, y_data):
-                writer.writerow([x, y])
+        try:
+            with open(filename, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(["Czas (s)", f"Dysk {self.mount} (%)"])
+                for x, y in zip(x_data, y_data):
+                    writer.writerow([x, y])
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc
 
 
 class GPUExporter(Exporter):
@@ -92,11 +102,14 @@ class GPUExporter(Exporter):
         """
         Eksportuje dane GPU do pliku CSV.
         """
-        with open(filename, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(["Czas (s)", f"GPU {self.name} (%)"])
-            for x, y in zip(x_data, y_data):
-                writer.writerow([x, y])
+        try:
+            with open(filename, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(["Czas (s)", f"GPU {self.name} (%)"])
+                for x, y in zip(x_data, y_data):
+                    writer.writerow([x, y])
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc
 
 
 class NetworkExporter(Exporter):
@@ -113,11 +126,14 @@ class NetworkExporter(Exporter):
         """
         Eksportuje dane sieci do pliku CSV.
         """
-        with open(filename, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(["Czas (s)", f"{self.label} (KB/s)"])
-            for x, y in zip(x_data, y_data):
-                writer.writerow([x, y])
+        try:
+            with open(filename, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(["Czas (s)", f"{self.label} (KB/s)"])
+                for x, y in zip(x_data, y_data):
+                    writer.writerow([x, y])
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc
 
 
 class MultiMetricExporter(Exporter):
@@ -138,15 +154,35 @@ class MultiMetricExporter(Exporter):
             x_data: Oś czasu.
             metrics: Słownik metryk (nazwa: lista wartości).
         """
-        with open(filename, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            header = ["Czas (s)"] + list(metrics.keys())
-            writer.writerow(header)
+        try:
+            with open(filename, mode='w', newline='') as file:
+                writer = csv.writer(file)
+                header = ["Czas (s)"] + list(metrics.keys())
+                writer.writerow(header)
 
-            for i in range(len(x_data)):
-                row = [x_data[i]] + [
-                    metrics[key][i] if i < len(metrics[key])
-                    else ''
-                    for key in metrics
-                ]
-                writer.writerow(row)
+                for i in range(len(x_data)):
+                    row = [x_data[i]] + [
+                        metrics[key][i] if i < len(metrics[key])
+                        else ''
+                        for key in metrics
+                    ]
+                    writer.writerow(row)
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc
+
+
+class JSONExporter(Exporter):
+    """Eksporter wielu metryk do pliku JSON."""
+
+    def export(
+        self,
+        filename: str,
+        x_data: List[int],
+        metrics: Dict[str, List[float]]
+    ) -> None:
+        """Zapisuje dane do pliku JSON."""
+        try:
+            with open(filename, mode='w', encoding='utf-8') as file:
+                json.dump({"x_data": x_data, "metrics": metrics}, file)
+        except OSError as exc:
+            raise RuntimeError(f"Nie można zapisać pliku {filename}: {exc}") from exc

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,4 +1,6 @@
 import csv
+import json
+import pytest
 
 
 def test_cpu_exporter_writes_csv(tmp_path):
@@ -28,4 +30,31 @@ def test_multi_metric_exporter_handles_ragged_data(tmp_path):
     assert rows[0] == ["Czas (s)", "CPU", "RAM"]
     # Third row has missing RAM value -> empty string
     assert rows[2] == ["1", "2.0", ""]
+
+
+def test_json_exporter_writes_json(tmp_path):
+    from exporter.exporters import JSONExporter
+    x = [0, 1, 2]
+    metrics = {"CPU": [10.0, 20.0, 30.0]}
+    out = tmp_path / "data.json"
+    JSONExporter().export(str(out), x, metrics)
+
+    with out.open() as f:
+        data = json.load(f)
+    assert data["x_data"] == x
+    assert data["metrics"] == metrics
+
+
+def test_ram_exporter_raises_runtime_error(tmp_path):
+    from exporter.exporters import RAMExporter
+    invalid = tmp_path / "missing" / "ram.csv"
+    with pytest.raises(RuntimeError):
+        RAMExporter().export(str(invalid), [0], [0.0])
+
+
+def test_json_exporter_raises_runtime_error(tmp_path):
+    from exporter.exporters import JSONExporter
+    invalid = tmp_path / "missing" / "data.json"
+    with pytest.raises(RuntimeError):
+        JSONExporter().export(str(invalid), [0], {"CPU": [0.0]})
 


### PR DESCRIPTION
## Summary
- add JSONExporter for saving x_data and metrics to JSON
- wrap exporter file writes in try/except to raise RuntimeError on failure
- test JSON exporting and error handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7241ab934833194501c21124e34e2