### PR TITLE
feat: add process monitor and GUI alerts

### DIFF
--- a/monitor/process_monitor.py
+++ b/monitor/process_monitor.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from typing import List
+
+import psutil
+
+
+@dataclass
+class ProcessUsage:
+    """Informacje o pojedynczym procesie."""
+
+    pid: int
+    name: str
+    cpu_percent: float
+    memory_percent: float
+
+
+class ProcessMonitor:
+    """Monitor zwracający listę procesów o najwyższym użyciu zasobów."""
+
+    def get_top_processes(
+        self, top_n: int = 5, sort_by: str = "cpu"
+    ) -> List[ProcessUsage]:
+        """Zwraca listę procesów posortowaną wg zużycia CPU lub pamięci RAM.
+
+        Args:
+            top_n: maksymalna liczba procesów do zwrócenia.
+            sort_by: kryterium sortowania ("cpu" lub "memory").
+        """
+        processes: List[ProcessUsage] = []
+        for proc in psutil.process_iter(
+            ["pid", "name", "cpu_percent", "memory_percent"]
+        ):
+            try:
+                info = proc.info
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+            processes.append(
+                ProcessUsage(
+                    pid=info.get("pid", 0),
+                    name=info.get("name", ""),
+                    cpu_percent=info.get("cpu_percent", 0.0),
+                    memory_percent=info.get("memory_percent", 0.0),
+                )
+            )
+
+        key = (
+            (lambda p: p.memory_percent)
+            if sort_by == "memory"
+            else (lambda p: p.cpu_percent)
+        )
+        processes.sort(key=key, reverse=True)
+        return processes[:top_n]

--- a/tests/test_process_monitor.py
+++ b/tests/test_process_monitor.py
@@ -1,0 +1,46 @@
+import psutil
+from types import SimpleNamespace
+
+from monitor.process_monitor import ProcessMonitor
+
+
+def test_get_top_processes_cpu(monkeypatch):
+    processes = [
+        SimpleNamespace(info={"pid": 1, "name": "a", "cpu_percent": 10.0, "memory_percent": 5.0}),
+        SimpleNamespace(info={"pid": 2, "name": "b", "cpu_percent": 50.0, "memory_percent": 15.0}),
+        SimpleNamespace(info={"pid": 3, "name": "c", "cpu_percent": 20.0, "memory_percent": 25.0}),
+    ]
+    monkeypatch.setattr(psutil, "process_iter", lambda attrs: iter(processes))
+    monitor = ProcessMonitor()
+    result = monitor.get_top_processes(top_n=2, sort_by="cpu")
+    assert [p.pid for p in result] == [2, 3]
+
+
+def test_get_top_processes_memory(monkeypatch):
+    processes = [
+        SimpleNamespace(info={"pid": 1, "name": "a", "cpu_percent": 10.0, "memory_percent": 5.0}),
+        SimpleNamespace(info={"pid": 2, "name": "b", "cpu_percent": 50.0, "memory_percent": 15.0}),
+        SimpleNamespace(info={"pid": 3, "name": "c", "cpu_percent": 20.0, "memory_percent": 25.0}),
+    ]
+    monkeypatch.setattr(psutil, "process_iter", lambda attrs: iter(processes))
+    monitor = ProcessMonitor()
+    result = monitor.get_top_processes(top_n=2, sort_by="memory")
+    assert [p.pid for p in result] == [3, 2]
+
+
+def test_get_top_processes_ignores_errors(monkeypatch):
+    class BadProc:
+        def __init__(self, exc):
+            self._exc = exc
+
+        @property
+        def info(self):
+            raise self._exc
+
+    good = SimpleNamespace(info={"pid": 1, "name": "a", "cpu_percent": 10.0, "memory_percent": 5.0})
+    bad = BadProc(psutil.NoSuchProcess(2))
+    monkeypatch.setattr(psutil, "process_iter", lambda attrs: iter([bad, good]))
+    monitor = ProcessMonitor()
+    result = monitor.get_top_processes(top_n=5)
+    assert [p.pid for p in result] == [1]
+


### PR DESCRIPTION
## Summary
- show top processes with live CPU and RAM usage
- allow CPU/RAM threshold alerts in the GUI
- cover process monitor with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c72b15ff548331bcb491a1629644b9