### PR TITLE
feat(config): persist user settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,59 @@
+"""Configuration utilities for the resource monitor application.
+
+This module provides helper functions to persist and retrieve user settings
+from a ``config.json`` file located in the repository root. The configuration
+currently stores the update interval, history length and threshold values used
+by the application.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+# ``config.py`` lives in the repository root, therefore ``CONFIG_FILE`` points
+# directly to ``config.json`` in the same directory.
+CONFIG_FILE = Path(__file__).with_name("config.json")
+
+# Default configuration used when the file does not exist or is invalid.
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "update_interval_ms": 1000,
+    "history_length": 60,
+    "cpu_threshold": 90,
+    "ram_threshold": 90,
+}
+
+
+def load_config() -> Dict[str, Any]:
+    """Load application configuration from ``config.json``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Configuration dictionary with default values filled in for any
+        missing keys.
+    """
+
+    if CONFIG_FILE.exists():
+        try:
+            with CONFIG_FILE.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            data = {}
+        return {**DEFAULT_CONFIG, **data}
+    return {}
+
+
+def save_config(config: Dict[str, Any]) -> None:
+    """Persist configuration to ``config.json``.
+
+    Parameters
+    ----------
+    config:
+        Dictionary containing configuration values to save.
+    """
+
+    with CONFIG_FILE.open("w", encoding="utf-8") as f:
+        json.dump(config, f, indent=4)
+

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,17 +1,22 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import config
 import main
 
 
 def dummy_build_gui(self):
-    self.ani = main.animation.FuncAnimation(None, self.update_plot, interval=self.update_interval_ms)
+    self.ani = main.animation.FuncAnimation(
+        None, self.update_plot, interval=self.update_interval_ms
+    )
 
 
 def make_root():
     root = MagicMock()
     root.title = lambda *_: None
     root.geometry = lambda *_: None
+    root.protocol = lambda *_: None
+    root.destroy = lambda: None
     return root
 
 
@@ -35,25 +40,33 @@ def patch_monitors(monkeypatch):
             get_usage=lambda: SimpleNamespace(upload_kbps=0, download_kbps=0)
         ),
     )
+    
+    class DummyVar:
+        def __init__(self, master=None, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    monkeypatch.setattr(main.tk, "StringVar", DummyVar)
 
 
-def test_custom_config(monkeypatch):
+def test_custom_config(monkeypatch, tmp_path):
     patch_monitors(monkeypatch)
     monkeypatch.setattr(main.ResourceMonitorApp, "build_gui", dummy_build_gui)
-    captured = {}
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
 
     def fake_anim(fig, func, interval):
-        captured["interval"] = interval
-        class Dummy:
-            def __init__(self, interval):
-                self.event_source = SimpleNamespace(interval=interval)
-        return Dummy(interval)
+        return SimpleNamespace(event_source=SimpleNamespace(interval=interval))
 
     monkeypatch.setattr(main.animation, "FuncAnimation", fake_anim)
     app = main.ResourceMonitorApp(make_root(), update_interval_ms=500, history_length=30)
     assert app.update_interval_ms == 500
     assert app.history_length == 30
-    assert captured["interval"] == 500
+    assert app.ani.event_source.interval == 500
 
     app.x_data = list(range(30))
     app.cpu_data = list(range(30))
@@ -61,3 +74,30 @@ def test_custom_config(monkeypatch):
     app.network_data = {"NET_UP": list(range(30)), "NET_DOWN": list(range(30))}
     app.update_plot(None)
     assert len(app.x_data) == 30
+
+
+def test_save_and_load_config(monkeypatch, tmp_path):
+    patch_monitors(monkeypatch)
+    monkeypatch.setattr(main.ResourceMonitorApp, "build_gui", dummy_build_gui)
+    monkeypatch.setattr(
+        main.animation,
+        "FuncAnimation",
+        lambda *a, **k: SimpleNamespace(
+            event_source=SimpleNamespace(interval=k.get("interval"))
+        ),
+    )
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+
+    app1 = main.ResourceMonitorApp(make_root())
+    app1.update_interval_ms = 1500
+    app1.history_length = 20
+    app1.cpu_threshold_var.set("75")
+    app1.ram_threshold_var.set("65")
+    app1.on_close()
+
+    app2 = main.ResourceMonitorApp(make_root())
+    assert app2.update_interval_ms == 1500
+    assert app2.history_length == 20
+    assert app2.cpu_threshold_var.get() == "75"
+    assert app2.ram_threshold_var.get() == "65"
+


### PR DESCRIPTION
## Summary
- add `config.py` to load and save app settings in `config.json`
- initialize `ResourceMonitorApp` from config and persist on close
- test that settings are saved and loaded correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c733add6e48331a07ae887631f0b24