### PR TITLE
fix: safely destroy root on close

### DIFF
--- a/main.py
+++ b/main.py
@@ -384,7 +384,7 @@ class ResourceMonitorApp:
                 "ram_threshold": ram_thr,
             }
         )
-        safe_call(self.root.destroy)
+        safe_call()(self.root.destroy)()
 
     def export_selected(self):
         """


### PR DESCRIPTION
## Summary
- correctly invoke safe_call decorator in `on_close`
- test configuration persistence and safe shutdown via `safe_call`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c736beb1d88331b8af9928b6e7c9a6