### PR TITLE
fix: use default config when file missing

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ def load_config() -> Dict[str, Any]:
         except json.JSONDecodeError:
             data = {}
         return {**DEFAULT_CONFIG, **data}
-    return {}
+    return DEFAULT_CONFIG.copy()
 
 
 def save_config(config: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- ensure config.load_config returns default settings when no config file exists
- verify default configuration via tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7379acbdc8331a83b9605946f75d4